### PR TITLE
Update SocketFlutterPlugin.java

### DIFF
--- a/android/src/main/java/net/ongbut/socketflutterplugin/SocketFlutterPlugin.java
+++ b/android/src/main/java/net/ongbut/socketflutterplugin/SocketFlutterPlugin.java
@@ -1,5 +1,7 @@
 package net.ongbut.socketflutterplugin;
 
+import android.os.Handler;
+import android.os.Looper;
 import android.util.Log;
 
 import java.net.URISyntaxException;
@@ -88,11 +90,16 @@ public class SocketFlutterPlugin implements MethodCallHandler {
   private Emitter.Listener onNewMessage = new Emitter.Listener() {
     @Override
     public void call(final Object... args) {
-        String data = (String)args[0];
-        Log.d("SocketIO ", "Received " + data);
-        Map<String, String> myMap= new HashMap<String, String>();
-        myMap.put("message", data);
-        channel.invokeMethod("received", myMap);
+      new Handler(Looper.getMainLooper()).post(new Runnable() {
+        @Override
+        public void run() {
+          String data = args[1].toString();
+          Log.d("SocketIO ", "Received " + data);
+          Map<String, String> myMap= new HashMap<String, String>();
+          myMap.put("message", data);
+          channel.invokeMethod("received", myMap);
+        };
+      });
     }
   };
 }


### PR DESCRIPTION
As on May 4 new changes to [flutter engine](https://github.com/flutter/engine/commit/2c9e37c34e79475bbde7c8163eb5e56cdb9662a1) this error rises:
Plugins crash with "Methods marked with @UiThread must be executed on the main thread."

And sometimes there is channel name on arg[0] so taking arg[1] in that case